### PR TITLE
[Hi-4] Optimal patch and stride sizes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# deepdespeckling Synthetic Aperture Radar (SAR) images with Pytorch
+# deepdespeckling 
+## Synthetic Aperture Radar (SAR) images despeckling with Pytorch
 
 Speckle fluctuations seriously limit the interpretability of synthetic aperture radar (SAR) images. This package provides despeckling methods that can highly improve the quality and interpretability of SAR images. Both Stripmap and Spotlight operations are handled by this package. 
  
@@ -9,7 +10,7 @@ To get a test function using Tensorflow's framework : https://gitlab.telecom-par
 [![PyPI version](https://badge.fury.io/py/deepdespeckling.svg)](https://badge.fury.io/py/deepdespeckling)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-# Installation
+## Installation
 
 Install deepdespeckling by running in the command prompt :
 
@@ -17,7 +18,7 @@ Install deepdespeckling by running in the command prompt :
 pip install deepdespeckling
 ```
 
-# Authors
+## Authors
 
 
 * [Emanuele Dalsasso](https://perso.telecom-paristech.fr/dalsasso/) (Researcher at Telecom Paris)
@@ -26,52 +27,62 @@ pip install deepdespeckling
 * [Hadrien Mariaccia](https://www.linkedin.com/in/hadrien-mar/) (Hi! PARIS Machine Learning Research Engineer)
 
 
-# Use cases
+## Examples
 
-### Test
 The package offers you 3 different methods for despeckling your SAR images: the fullsize method, the coordinates based method and the crop method.
 
-1) I have a high-resolution SAR image and I want to apply the despeckling function to the whole of it:
+### Despeckle fullsize images
 
 ```python
 from deepdespeckling.merlin.inference.despeckling import despeckle
 
+# Path to one image (cos or npy file), can also be a folder of several images
 image_path="path/to/cosar/image"
+# Folder where results are stored
 destination_directory="path/where/to/save/results"
+# Path to the model weights of the model (pth file)
 model_weights_path="path/to/model/weights"
 
-despeckle(image_path, destination_directory, model_weights_path=model_weights_path)
+denoised_image = despeckle(image_path, destination_directory, model_weights_path=model_weights_path)
 ```
 Noisy image             |  Denoised image
 :----------------------:|:-------------------------:
 ![](img/entire/noisy.png)  |  ![](img/entire/denoised.png)
 
-2) I have a high-resolution SAR image but I only want to apply the despeckling function to a specific area for which I know the coordinates:
+### Despeckle parts of images using custom coordinates
+
 ```python
 from deepdespeckling.merlin.inference.despeckling import despeckle_from_coordinates
 
+# Path to one image (cos or npy file), can also be a folder of several images
 image_path="path/to/cosar/image"
+# Folder where results are stored
 destination_directory="path/where/to/save/results"
+# Path to the model weights of the model (pth file)
 model_weights_path="path/to/model/weights"
 coordinates_dictionnary = {'x_start':2600,'y_start':1000,'x_end':3000,'y_end':1200}
 
-despeckle_from_coordinates(image_path, coordinates_dict, destination_directory, model_weights_path)
-````
+denoised_image = despeckle_from_coordinates(image_path, coordinates_dict, destination_directory, model_weights_path)
+```
 
 Noisy image             |  Denoised image
 :----------------------:|:-------------------------:
 ![](img/coordinates/noisy_test_image_data.png)  |  ![](img/coordinates/denoised_test_image_data.png)
 
-3) I have a high-resolution SAR image but I want to apply the despeckling function to an area I want to select with a crop:
+### Despeckle parts of images using a crop tool
+
 ```python
 from deepdespeckling.merlin.inference.despeckling import despeckle_from_crop
 
+# Path to one image (cos or npy file), can also be a folder of several images
 image_path="path/to/cosar/image"
+# Folder where results are stored
 destination_directory="path/where/to/save/results"
+# Path to the model weights of the model (pth file)
 model_weights_path="path/to/model/weights"
 fixed = True "(it will crop a 256*256 image from the position of your click)" or False "(you will draw free-handly the area of your interest)"
 
-despeckle_from_crop(image_path, destination_directory, model_weights_path, fixed=False)
+denoised_image = despeckle_from_crop(image_path, destination_directory, model_weights_path, fixed=False)
 ```
 
 * The cropping tool: Just select an area and press "q" when you are satisfied with the crop !
@@ -86,8 +97,8 @@ Noisy cropped image                     |           Denoised cropped image
 :-----------------------------------------------------------:|:------------------------------------------:
  <img src="img/crop/noisy_test_image_data.png" width="100%"> | <img src="img/crop/denoised_test_image_data.png" width="1000%">
 
-you can use the same features for stripmap images by changing the weights_path 
-### Train
+
+### Train a new model
 
 1) I want to train my own model from scratch:
 ```python

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ image_path="path/to/cosar/image"
 destination_directory="path/where/to/save/results"
 model_weights_path="path/to/model/weights"
 
-despeckle_spotlight(image_path,destination_directory,model_weights_path=model_weights_path)
+despeckle(image_path, destination_directory, model_weights_path=model_weights_path)
 ```
 Noisy image             |  Denoised image
 :----------------------:|:-------------------------:
@@ -55,7 +55,7 @@ destination_directory="path/where/to/save/results"
 model_weights_path="path/to/model/weights"
 coordinates_dictionnary = {'x_start':2600,'y_start':1000,'x_end':3000,'y_end':1200}
 
-despeckle_from_coordinates_spotlight(image_path, coordinates_dict, destination_directory, model_weights_path)
+despeckle_from_coordinates(image_path, coordinates_dict, destination_directory, model_weights_path)
 ````
 
 Noisy image             |  Denoised image
@@ -71,7 +71,7 @@ destination_directory="path/where/to/save/results"
 model_weights_path="path/to/model/weights"
 fixed = True "(it will crop a 256*256 image from the position of your click)" or False "(you will draw free-handly the area of your interest)"
 
-despeckle_from_crop_spotlight(image_path, destination_directory, model_weights_path, fixed=False)
+despeckle_from_crop(image_path, destination_directory, model_weights_path, fixed=False)
 ```
 
 * The cropping tool: Just select an area and press "q" when you are satisfied with the crop !
@@ -107,7 +107,7 @@ sample_directory="path/to/sample/data"
 from_pretrained=False
 
 model=create_model(batch_size=12,val_batch_size=1,device=torch.device("cuda:0" if torch.cuda.is_available() else "cpu"),from_pretrained=from_pretrained)
-fit_model(model,lr,nb_epoch,training_set_directory,validation_set_directory,sample_directory,save_directory,seed=2)
+fit_model(model, lr, nb_epoch, training_set_directory, validation_set_directory, sample_directory, save_directory, seed=2)
 
 ```
 
@@ -129,8 +129,8 @@ save_directory="path/where/to/save/results"
 sample_directory="path/to/sample/data"
 from_pretrained=True
 
-model=create_model(Model,batch_size=12,val_batch_size=1,device=torch.device("cuda:0" if torch.cuda.is_available() else "cpu"),from_pretrained=from_pretrained)
-fit_model(model,lr,nb_epoch,training_set_directory,validation_set_directory,sample_directory,save_directory,seed=2)
+model=create_model(Model, batch_size=12, val_batch_size=1, device=torch.device("cuda:0" if torch.cuda.is_available() else "cpu"), from_pretrained=from_pretrained)
+fit_model(model, lr, nb_epoch, training_set_directory, validation_set_directory, sample_directory, save_directory, seed=2)
 ```
 
 # Contribute

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # deepdespeckling 
 ## Synthetic Aperture Radar (SAR) images despeckling with Pytorch
 
-Speckle fluctuations seriously limit the interpretability of synthetic aperture radar (SAR) images. This package provides despeckling methods that can highly improve the quality and interpretability of SAR images. Both Stripmap and Spotlight operations are handled by this package. 
+Speckle fluctuations seriously limit the interpretability of synthetic aperture radar (SAR) images. This package provides despeckling methods that are leveraging deep learning to highly improve the quality and interpretability of SAR images. Both Stripmap and Spotlight operations are handled by this package. 
  
-The package contains both test and train parts, wether you wish to despeckle a single pic (test) or use our model to build or improve your own.
+The package contains both inference and training parts, wether you wish to despeckle a set of SAR images or use our model to build or improve your own.
 
 To get a test function using Tensorflow's framework : https://gitlab.telecom-paris.fr/ring/MERLIN/-/blob/master/README.md
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ from deepdespeckling.merlin.inference.despeckling import despeckle
 image_path="path/to/cosar/image"
 # Folder where results are stored
 destination_directory="path/where/to/save/results"
-# Path to the model weights of the model (pth file)
+# Path to the model weights (pth file)
 model_weights_path="path/to/model/weights"
 
 denoised_image = despeckle(image_path, destination_directory, model_weights_path=model_weights_path)
@@ -58,7 +58,7 @@ from deepdespeckling.merlin.inference.despeckling import despeckle_from_coordina
 image_path="path/to/cosar/image"
 # Folder where results are stored
 destination_directory="path/where/to/save/results"
-# Path to the model weights of the model (pth file)
+# Path to the model weights (pth file)
 model_weights_path="path/to/model/weights"
 coordinates_dictionnary = {'x_start':2600,'y_start':1000,'x_end':3000,'y_end':1200}
 
@@ -78,7 +78,7 @@ from deepdespeckling.merlin.inference.despeckling import despeckle_from_crop
 image_path="path/to/cosar/image"
 # Folder where results are stored
 destination_directory="path/where/to/save/results"
-# Path to the model weights of the model (pth file)
+# Path to the model weights (pth file)
 model_weights_path="path/to/model/weights"
 fixed = True "(it will crop a 256*256 image from the position of your click)" or False "(you will draw free-handly the area of your interest)"
 

--- a/deepdespeckling/merlin/inference/despeckling.py
+++ b/deepdespeckling/merlin/inference/despeckling.py
@@ -40,7 +40,7 @@ def despeckle(sar_images_path, destination_directory_path, stride_size=64, model
     logging.info(
         f"Starting inference.. Working directory: {os.getcwd()}. Collecting data from {sar_images_path} and storing test results in {destination_directory_path}")
     denoised_image = Denoiser().denoise_images(images_to_denoise_paths=processed_images_paths, weights_path=model_weights_path, save_dir=destination_directory_path,
-                                               stride=stride_size, patch_size=patch_size)
+                                               stride=stride_size)
 
     return denoised_image
 
@@ -75,7 +75,7 @@ def despeckle_from_coordinates(sar_images_path, coordinates_dict, destination_di
     processed_images_paths = glob((processed_images_path + '/*.npy'))
 
     denoised_image = Denoiser().denoise_images(images_to_denoise_paths=processed_images_paths, weights_path=model_weights_path, save_dir=destination_directory_path,
-                                               stride=stride_size, patch_size=patch_size)
+                                               stride=stride_size)
 
     return denoised_image
 
@@ -145,6 +145,6 @@ def despeckle_from_crop(sar_images_path, destination_directory_path, stride_size
     logging.info(
         f"Starting inference.. Working directory: {os.getcwd()}. Collecting data from {sar_images_path} and storing test results in {destination_directory_path}")
     denoised_image = Denoiser().denoise_images(images_to_denoise_paths=processed_cropped_images_paths, weights_path=model_weights_path, save_dir=destination_directory_path,
-                                               stride=stride_size, patch_size=patch_size)
+                                               stride=stride_size)
 
     return denoised_image

--- a/deepdespeckling/merlin/inference/model.py
+++ b/deepdespeckling/merlin/inference/model.py
@@ -3,13 +3,13 @@ import torch
 
 class Model(torch.nn.Module):
 
-    def __init__(self, device):
+    def __init__(self, device, height, width):
         super().__init__()
 
         self.device = device
 
-        self.height = 256
-        self.width = 256
+        self.height = height
+        self.width = width
 
         self.pool = torch.nn.MaxPool2d(kernel_size=2, stride=2)
         self.leaky = torch.nn.LeakyReLU(0.1)

--- a/deepdespeckling/merlin/training/GenerateDataset.py
+++ b/deepdespeckling/merlin/training/GenerateDataset.py
@@ -2,6 +2,8 @@ import glob
 import numpy as np
 from scipy import signal
 
+from deepdespeckling.utils.constants import PATCH_SIZE
+
 
 '''
 Generate patches for the images in the folder dataset/data/Train
@@ -92,7 +94,7 @@ class GenerateDataset():
         ima2 = np.fft.ifft2(np.fft.ifftshift(Sf))
         return np.stack((np.real(ima2), np.imag(ima2)), axis=2)
 
-    def generate_patches(self, src_dir="./dataset/data/Train", patch_size=256, step=0, stride=64, bat_size=4, data_aug_times=1, n_channels=2):
+    def generate_patches(self, src_dir="./dataset/data/Train", patch_size=PATCH_SIZE, step=0, stride=64, bat_size=4, data_aug_times=1, n_channels=2):
         count = 0
         filepaths = glob.glob(src_dir + '/*.npy')
         print("number of training data %d" % len(filepaths))

--- a/deepdespeckling/merlin/training/train.py
+++ b/deepdespeckling/merlin/training/train.py
@@ -1,10 +1,11 @@
 from glob import glob
 import os
 import torch
+from deepdespeckling.merlin.training.GenerateDataset import GenerateDataset
 
 from deepdespeckling.merlin.training.Dataset import Dataset, ValDataset
 from deepdespeckling.merlin.training.model import Model
-from deepdespeckling.utils.utils import load_train_data
+from deepdespeckling.utils.constants import PATCH_SIZE
 
 
 def evaluate(model, loader):
@@ -113,7 +114,7 @@ def create_model(batch_size=12, val_batch_size=1, device=torch.device("cuda:0" i
 
 
 def fit_model(model, lr_list, nb_epoch, training_set_directory, validation_set_directory, sample_directory,
-              save_directory, patch_size=256, batch_size=12, val_batch_size=1, stride_size=128,
+              save_directory, patch_size=PATCH_SIZE, batch_size=12, val_batch_size=1, stride_size=128,
               n_data_augmentation=1, seed=2, clip_by_norm=True):
     """ Runs the denoiser algorithm for the training and evaluation dataset
 
@@ -129,9 +130,10 @@ def fit_model(model, lr_list, nb_epoch, training_set_directory, validation_set_d
     """
     torch.manual_seed(seed)
 
+    train_data = GenerateDataset().generate_patches(src_dir=training_set_directory, patch_size=patch_size, step=0,
+                                                    stride=stride_size, bat_size=batch_size, data_aug_times=n_data_augmentation)
+
     # Prepare train DataLoader
-    train_data = load_train_data(training_set_directory, patch_size,
-                                 batch_size, stride_size, n_data_augmentation)  # range [0; 1]
     train_dataset = Dataset(train_data)
     train_loader = torch.utils.data.DataLoader(
         train_dataset, batch_size=batch_size, shuffle=True, drop_last=True)

--- a/deepdespeckling/test_deepdespeckling.py
+++ b/deepdespeckling/test_deepdespeckling.py
@@ -1,10 +1,10 @@
-from deepdespeckling.merlin.inference.despeckling import despeckle
+from deepdespeckling.merlin.inference.despeckling import despeckle_from_coordinates
 
 image_path = "/Users/hadrienmariaccia/Documents/Projects/deepdespeckling/img/entire"
 destination_directory = "/Users/hadrienmariaccia/Documents/Projects/deepdespeckling/img/entire"
 model_weights_path = "/Users/hadrienmariaccia/Documents/Projects/deepdespeckling/deepdespeckling/merlin/inference/saved_model/spotlight.pth"
 coordinates_dictionnary = {'x_start': 0,
-                           'y_start': 0, 'x_end': 1200, 'y_end': 1200}
+                           'y_start': 0, 'x_end': 700, 'y_end': 700}
 
-despeckle(image_path, destination_directory,
-          model_weights_path=model_weights_path)
+despeckle_from_coordinates(image_path, coordinates_dictionnary, destination_directory,
+                           model_weights_path=model_weights_path)

--- a/deepdespeckling/utils/constants.py
+++ b/deepdespeckling/utils/constants.py
@@ -1,10 +1,5 @@
 from scipy import special
 import numpy as np
 
-# TODO : Rename the following constants
-
 M = 10.089038980848645
 m = -1.429329123112601
-L = 1
-c = (1 / 2) * (special.psi(L) - np.log(L))
-cn = c / (M - m)  # normalized (0,1) mean of log speckle

--- a/deepdespeckling/utils/constants.py
+++ b/deepdespeckling/utils/constants.py
@@ -1,5 +1,14 @@
 from scipy import special
 import numpy as np
 
+# Global maximum and minimum values obtained empirically and used to normalize SAR images
 M = 10.089038980848645
 m = -1.429329123112601
+
+# Must be a power of 2 lower than min(height, width) of the image to despeckle
+# Default to 256 as the trained spotlight and stripmap models stored in merlin/saved_model
+PATCH_SIZE = 256
+
+# Has to be lower than the PATCH_SIZE
+# Default to PATCH_SIZE - 2 in order to not have visible borders in the despeckled images
+STRIDE_SIZE = PATCH_SIZE - 2

--- a/deepdespeckling/utils/utils.py
+++ b/deepdespeckling/utils/utils.py
@@ -92,10 +92,6 @@ def create_empty_folder_in_directory(destination_directory_path, folder_name="pr
     processed_images_path = destination_directory_path + f'/{folder_name}'
     if not os.path.exists(processed_images_path):
         os.mkdir(processed_images_path)
-    else:
-        filelist = glob(os.path.join(processed_images_path, "*"))
-        for f in filelist:
-            os.remove(f)
     return processed_images_path
 
 
@@ -109,9 +105,10 @@ def preprocess_and_store_sar_images(sar_images_path, processed_images_path):
     images_paths = glob(os.path.join(sar_images_path, "*.cos")) + \
         glob(os.path.join(sar_images_path, "*.npy"))
     for image_path in images_paths:
-        image = load_sar_image(image_path)
-        imagename = image_path.split('/')[-1].split('.')[0]
-        np.save(processed_images_path + '/' + imagename + '.npy', image)
+        if not os.path.exists(processed_images_path + '/' + imagename + '.npy'):
+            image = load_sar_image(image_path)
+            imagename = image_path.split('/')[-1].split('.')[0]
+            np.save(processed_images_path + '/' + imagename + '.npy', image)
 
 
 def preprocess_and_store_sar_images_from_coordinates(sar_images_path, processed_images_path, coordinates_dict):
@@ -130,10 +127,11 @@ def preprocess_and_store_sar_images_from_coordinates(sar_images_path, processed_
     images_paths = glob(os.path.join(sar_images_path, "*.cos")) + \
         glob(os.path.join(sar_images_path, "*.npy"))
     for image_path in images_paths:
-        image = load_sar_image(image_path)
-        imagename = image_path.split('/')[-1].split('.')[0]
-        np.save(processed_images_path + '/' + imagename +
-                '.npy', image[x_start:x_end, y_start:y_end, :])
+        if not os.path.exists(processed_images_path + '/' + imagename + '.npy'):
+            image = load_sar_image(image_path)
+            imagename = image_path.split('/')[-1].split('.')[0]
+            np.save(processed_images_path + '/' + imagename +
+                    '.npy', image[x_start:x_end, y_start:y_end, :])
 
 
 def get_maximum_patch_size(kernel_size, patch_bound):

--- a/deepdespeckling/utils/utils.py
+++ b/deepdespeckling/utils/utils.py
@@ -136,6 +136,48 @@ def preprocess_and_store_sar_images_from_coordinates(sar_images_path, processed_
                 '.npy', image[x_start:x_end, y_start:y_end, :])
 
 
+def get_maximum_patch_size(kernel_size, patch_bound):
+    """Get maximum manifold of a number lower than a bound
+
+    Args:
+        kernel_size (int): the kernel size of the trained model
+        patch_bound (int): the maximum bound of the kernel size
+
+    Returns:
+        maximum_patch_size (int) : the maximum patch size
+    """
+    k = 1
+
+    while kernel_size * k < patch_bound:
+        k = k + 1
+
+    maximum_patch_size = kernel_size * (k-1)
+
+    return maximum_patch_size
+
+
+def get_maximum_patch_size_from_image_dimensions(kernel_size, height, width):
+    """Get the maximum patch size from the width and heigth and the kernel size of the model we use
+
+    Args:
+        kernel_size (int): the kernel size of the trained model
+        height (int): the heigth of the image
+        width (int): the width of the image
+
+    Returns:
+        maximum_patch_size (int) : the maximum patch size to use for despeckling
+    """
+    patch_bound = min(height, width)
+
+    if patch_bound <= kernel_size:
+        maximum_patch_size = kernel_size
+    else:
+        maximum_patch_size = get_maximum_patch_size(
+            kernel_size=kernel_size, patch_bound=patch_bound)
+
+    return maximum_patch_size
+
+
 def symetrisation_patch(ima):
     S = np.fft.fftshift(np.fft.fft2(ima[:, :, 0]+1j*ima[:, :, 1]))
     p = np.zeros((S.shape[0]))  # azimut (ncol)

--- a/deepdespeckling/utils/utils.py
+++ b/deepdespeckling/utils/utils.py
@@ -8,7 +8,7 @@ from glob import glob
 
 from deepdespeckling.merlin.inference.load_cosar import cos2mat
 from deepdespeckling.merlin.training.GenerateDataset import GenerateDataset
-from deepdespeckling.utils.constants import M, m, L, c, cn
+from deepdespeckling.utils.constants import M, m
 
 
 def normalize_sar(im):
@@ -105,9 +105,9 @@ def preprocess_and_store_sar_images(sar_images_path, processed_images_path):
     images_paths = glob(os.path.join(sar_images_path, "*.cos")) + \
         glob(os.path.join(sar_images_path, "*.npy"))
     for image_path in images_paths:
+        imagename = image_path.split('/')[-1].split('.')[0]
         if not os.path.exists(processed_images_path + '/' + imagename + '.npy'):
             image = load_sar_image(image_path)
-            imagename = image_path.split('/')[-1].split('.')[0]
             np.save(processed_images_path + '/' + imagename + '.npy', image)
 
 
@@ -127,9 +127,9 @@ def preprocess_and_store_sar_images_from_coordinates(sar_images_path, processed_
     images_paths = glob(os.path.join(sar_images_path, "*.cos")) + \
         glob(os.path.join(sar_images_path, "*.npy"))
     for image_path in images_paths:
+        imagename = image_path.split('/')[-1].split('.')[0]
         if not os.path.exists(processed_images_path + '/' + imagename + '.npy'):
             image = load_sar_image(image_path)
-            imagename = image_path.split('/')[-1].split('.')[0]
             np.save(processed_images_path + '/' + imagename +
                     '.npy', image[x_start:x_end, y_start:y_end, :])
 
@@ -147,11 +147,11 @@ def get_maximum_patch_size(kernel_size, patch_bound):
     k = 1
 
     while kernel_size * k < patch_bound:
-        k = k + 1
+        k = k * 2
 
-    maximum_patch_size = kernel_size * (k-1)
+    maximum_patch_size = int(kernel_size * (k/2))
 
-    return maximum_patch_size
+    return 256
 
 
 def get_maximum_patch_size_from_image_dimensions(kernel_size, height, width):


### PR DESCRIPTION
We wanted to check if the most efficient patch size, execution time wise, was the biggest manifold of the kernel size used for training that is lower than min(height, width) of the image to despeckle. Hence, we wanted to set this patch size dynamically depending on the image size if it was the case. 

After some tests, the most efficient patch size is the same as the kernel size used for training. The lower the patch size, the better the leverage of the GPU acceleration and parallelisation. On the other hand, we can significantly improve the computation time by increasing the `stride_size` to make it equals to the patch size, the results of the despeckling can be diminished as the borders of the patch can be seen on the denoised images but the gain in time is significant. 

Default patch size for inference is set to **256** (the patch size used for training). Default stride size is set to : patch size - 2 in order to not see the borders on the despeckled images while optimising the computation time. 

Beside this, some refactoring is done

TODO: 
- Continue refactoring 
- Improve code cleanness 
- Add tests 
- Add SAR2SAR as inference method 