### PR TITLE
Sphinx documentation generation files 

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,14 @@ destination_directory="path/where/to/save/results"
 despeckle(image_path, destination_directory, model_name="sar2sar")
 ```
 
+## Documentation
+
+To read a clean documentation of the package, you can generate it using sphinx files in the `docs` folder
+
+1. `cd docs`
+2. `make html `
+3. open `build/index.html`
+
 ## Authors
 
 * [Emanuele Dalsasso](https://emanueledalsasso.github.io/) (Researcher at ECEO, EPFL)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,48 @@
+import sys
+import os
+
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+sys.path.insert(0, os.path.abspath('../'))
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'deepdespeckling'
+copyright = '2024, Hadrien Mariaccia, Emanuele Delsasso'
+author = 'Hadrien Mariaccia, Emanuele Delsasso'
+release = '0.3'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'sphinx.ext.napoleon'
+]
+
+templates_path = ['_templates']
+exclude_patterns = ["build", ".venv", ".vscode",
+                    "dist", "deepdespeckling.egg-info", "img", "icons"]
+
+language = 'English'
+
+master_doc = "index"
+
+autodoc_default_options = {
+    'members': True,
+    'undoc-members': True,
+    'show-inheritance': True,
+}
+
+add_module_names = True
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'alabaster'
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,22 @@
+.. deepdespeckling documentation master file, created by
+   sphinx-quickstart on Thu Mar 28 11:09:21 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to deepdespeckling's documentation!
+===========================================
+
+.. toctree::
+   :maxdepth: 3
+   :caption: Contents:
+
+   modules
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,72 @@
+.. toctree::
+   :maxdepth: 3
+   :caption: Contents:
+
+deepdespeckling
+=================
+.. automodule:: deepdespeckling
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+denoiser
+--------
+
+.. automodule:: deepdespeckling.denoiser
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+despeckling
+--------
+
+.. automodule:: deepdespeckling.despeckling
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+model
+--------
+
+.. automodule:: deepdespeckling.model
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+merlin_denoiser
+--------
+
+.. automodule:: deepdespeckling.merlin.merlin_denoiser
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+sar2sar_denoiser
+--------
+
+.. automodule:: deepdespeckling.sar2sar.sar2sar_denoiser
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+utils
+--------
+
+.. automodule:: deepdespeckling.utils.utils
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+load_cosar
+--------
+
+.. automodule:: deepdespeckling.utils.load_cosar
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+


### PR DESCRIPTION
Add a `docs` folder with files for sphinx generation documentation

To generate the documentation : 

1. `cd docs`
2. `make html `
3. open `build/index.html`